### PR TITLE
JvmFallbackShutdown: don't activate in test environments

### DIFF
--- a/src/test/java/com/opentable/util/TestJvmFallbackShutdown.java
+++ b/src/test/java/com/opentable/util/TestJvmFallbackShutdown.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.junit.Test;
+
+public class TestJvmFallbackShutdown {
+    @Test
+    public void testInTests() throws Exception {
+        assertTrue(isInTests());
+    }
+
+    @Test
+    public void testNotInTests() throws Exception {
+        ExecutorService e = Executors.newSingleThreadExecutor();
+        Future<Boolean> f = e.submit(TestJvmFallbackShutdown::isInTests);
+        e.shutdown();
+        assertFalse(f.get());
+    }
+
+    private static boolean isInTests() {
+        Throwable t = new Throwable();
+        t.fillInStackTrace();
+        return JvmFallbackShutdown.inTests(t);
+    }
+}


### PR DESCRIPTION
This causes problems when you run integration tests on your built server --
since the JVM is reused for multiple test cases, calling System.exit
is wholly inappropriate.

So let's just disable the whole thing if we detect JUnit or Surefire.