### PR TITLE
JvmFallbackShutdown: only inhibit from junit runners, not just e.g. rules

### DIFF
--- a/src/main/java/com/opentable/util/JvmFallbackShutdown.java
+++ b/src/main/java/com/opentable/util/JvmFallbackShutdown.java
@@ -89,6 +89,6 @@ public final class JvmFallbackShutdown {
     static boolean inTests(Throwable source) {
         return Arrays.stream(source.getStackTrace())
             .anyMatch(e -> e.getClassName().contains("surefire.booter.ForkedBooter") ||
-                           e.getClassName().contains("org.junit"));
+                           e.getClassName().contains("org.junit.runner"));
     }
 }


### PR DESCRIPTION
If your class happens to extend junit's `ExternalResource` for example, this can cause false positives.