### PR TITLE
ThrowingSupplier: Similar to ThrowingFunction but for java.util.function.Supplier

### DIFF
--- a/src/main/java/com/opentable/function/ThrowingSupplier.java
+++ b/src/main/java/com/opentable/function/ThrowingSupplier.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.function;
+
+import java.util.function.Supplier;
+
+/**
+ * An alternative to {@link Supplier} that throws a checked {@link Exception}
+ *
+ * @param <T> the type of the result of the supplier.
+ */
+@FunctionalInterface
+public interface ThrowingSupplier<T> {
+    /**
+     * Gets a result.
+     * @return the result.
+     * @throws Exception the possible error when trying to get the result.
+     */
+    T get() throws Exception;
+}


### PR DESCRIPTION
Sometimes we need something similar to java.util.function.Supplier but that might throw a checked exception, although it's easy to implement, it's better to have it defined once for all.